### PR TITLE
Added the shortcut for MacOs users

### DIFF
--- a/src/webviewPanel/webviewPanel.ts
+++ b/src/webviewPanel/webviewPanel.ts
@@ -210,7 +210,7 @@ export default class WarmUpPanel {
           <h2 id="header">
             Warm Up - Typing test
           </h2>
-          <p id="subtitle">Hit "ctrl+shift+p" and enter "warmup" to see available commands</p>
+          <p id="subtitle">Hit "cmd/ctrl+shift+p" and enter "warmup" to see available commands</p>
         </div>
 
         <div id="command-center">


### PR DESCRIPTION
In the `webviewPanel`, the subtitle is:
```
Hit "ctrl+shift+p" ...
```
I changed this to suit MacOs users too:
```
Hit "cmd/ctrl+shift+p" ...
```